### PR TITLE
feat: add GA tracking with cookie banner 

### DIFF
--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -4,11 +4,23 @@ import { isBrowser } from "../lib/services/analytics";
 interface CookieBannerProps {
   onAccept: () => void;
   onReject: () => void;
+  onVisibilityChange?: (isVisible: boolean) => void;
 }
 
-export default function CookieBanner({ onAccept, onReject }: CookieBannerProps) {
+export default function CookieBanner({
+  onAccept,
+  onReject,
+  onVisibilityChange,
+}: CookieBannerProps) {
   const [isVisible, setIsVisible] = useState(false);
   const bannerRef = useRef<HTMLDivElement>(null);
+
+  // Notify parent when visibility changes
+  useEffect(() => {
+    if (onVisibilityChange) {
+      onVisibilityChange(isVisible);
+    }
+  }, [isVisible, onVisibilityChange]);
 
   useEffect(() => {
     // Only run in browser environment
@@ -58,7 +70,7 @@ export default function CookieBanner({ onAccept, onReject }: CookieBannerProps) 
       role="alertdialog"
       aria-labelledby="cookie-title"
       aria-describedby="cookie-description"
-      className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg"
+      className="p-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg w-full"
       tabIndex={-1}
     >
       <div className="container mx-auto flex flex-col md:flex-row justify-between items-center gap-4">

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect } from "react";
+
+interface CookieBannerProps {
+  onAccept: () => void;
+  onReject: () => void;
+}
+
+export default function CookieBanner({ onAccept, onReject }: CookieBannerProps) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    // Check if user has already made a choice
+    const cookieConsent = localStorage.getItem("cookie-consent");
+    if (!cookieConsent) {
+      setIsVisible(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    localStorage.setItem("cookie-consent", "accepted");
+    setIsVisible(false);
+    onAccept();
+  };
+
+  const handleReject = () => {
+    localStorage.setItem("cookie-consent", "rejected");
+    setIsVisible(false);
+    onReject();
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg">
+      <div className="container mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
+        <div className="text-sm text-gray-700 dark:text-gray-300">
+          We use cookies to improve your experience on our site. You can accept all cookies or
+          customize your preferences.
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={handleReject}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 rounded-md transition-colors"
+          >
+            Reject All
+          </button>
+          <button
+            onClick={handleAccept}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-md transition-colors"
+          >
+            Accept All
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { isBrowser } from "../lib/services/analytics";
 
 interface CookieBannerProps {
   onAccept: () => void;
@@ -9,6 +10,9 @@ export default function CookieBanner({ onAccept, onReject }: CookieBannerProps) 
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
+    // Only run in browser environment
+    if (!isBrowser) return;
+
     // Check if user has already made a choice
     const cookieConsent = localStorage.getItem("cookie-consent");
     if (!cookieConsent) {
@@ -17,17 +21,24 @@ export default function CookieBanner({ onAccept, onReject }: CookieBannerProps) 
   }, []);
 
   const handleAccept = () => {
-    localStorage.setItem("cookie-consent", "accepted");
+    // Only attempt to use localStorage in browser
+    if (isBrowser) {
+      localStorage.setItem("cookie-consent", "accepted");
+    }
     setIsVisible(false);
     onAccept();
   };
 
   const handleReject = () => {
-    localStorage.setItem("cookie-consent", "rejected");
+    // Only attempt to use localStorage in browser
+    if (isBrowser) {
+      localStorage.setItem("cookie-consent", "rejected");
+    }
     setIsVisible(false);
     onReject();
   };
 
+  // Don't render anything during SSR or if user has already made a choice
   if (!isVisible) return null;
 
   return (

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { isBrowser } from "../lib/services/analytics";
 
 interface CookieBannerProps {
@@ -8,17 +8,28 @@ interface CookieBannerProps {
 
 export default function CookieBanner({ onAccept, onReject }: CookieBannerProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const bannerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     // Only run in browser environment
     if (!isBrowser) return;
+
+    // Add escape key handler
+    const handleEscapeKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && isVisible) {
+        handleReject();
+      }
+    };
 
     // Check if user has already made a choice
     const cookieConsent = localStorage.getItem("cookie-consent");
     if (!cookieConsent) {
       setIsVisible(true);
     }
-  }, []);
+
+    window.addEventListener("keydown", handleEscapeKey);
+    return () => window.removeEventListener("keydown", handleEscapeKey);
+  }, [isVisible]);
 
   const handleAccept = () => {
     // Only attempt to use localStorage in browser
@@ -42,24 +53,38 @@ export default function CookieBanner({ onAccept, onReject }: CookieBannerProps) 
   if (!isVisible) return null;
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg">
+    <div
+      ref={bannerRef}
+      role="alertdialog"
+      aria-labelledby="cookie-title"
+      aria-describedby="cookie-description"
+      className="fixed bottom-0 left-0 right-0 z-50 p-4 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 shadow-lg"
+      tabIndex={-1}
+    >
       <div className="container mx-auto flex flex-col md:flex-row justify-between items-center gap-4">
         <div className="text-sm text-gray-700 dark:text-gray-300">
-          We use cookies to improve your experience on our site. You can accept all cookies or
-          customize your preferences.
+          <h2 id="cookie-title" className="sr-only">
+            Cookie Consent
+          </h2>
+          <p id="cookie-description">
+            We use cookies to track usage and improve the site. You can accept or reject these
+            cookies.
+          </p>
         </div>
         <div className="flex gap-2">
           <button
             onClick={handleReject}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 rounded-md transition-colors"
+            aria-label="Reject cookies"
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 dark:text-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500"
           >
-            Reject All
+            Reject
           </button>
           <button
             onClick={handleAccept}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-md transition-colors"
+            aria-label="Accept cookies"
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 rounded-md transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
-            Accept All
+            Accept
           </button>
         </div>
       </div>

--- a/src/lib/constants/site.ts
+++ b/src/lib/constants/site.ts
@@ -1,0 +1,9 @@
+/**
+ * Site-wide constants
+ */
+
+// Site version information
+export const SITE_VERSION = "1.1";
+
+// Analytics constants
+export const GA_MEASUREMENT_ID = "G-DJHT1QG9GK";

--- a/src/lib/hooks/useAnalyticsConsent.ts
+++ b/src/lib/hooks/useAnalyticsConsent.ts
@@ -3,29 +3,37 @@ import {
   hasAnalyticsConsent,
   updateAnalyticsConsent,
   initializeAnalytics,
+  isBrowser,
 } from "../services/analytics";
+import { SITE_VERSION } from "../constants/site";
 
 // Hook to manage analytics consent
 export function useAnalyticsConsent() {
   const [consent, setConsent] = useState<boolean | null>(null);
 
   useEffect(() => {
+    if (!isBrowser) return;
+
     // Check for existing consent
     const hasConsent = hasAnalyticsConsent();
     setConsent(hasConsent);
 
     // Initialize analytics with the current consent setting
-    if (typeof window !== "undefined") {
-      initializeAnalytics();
+    initializeAnalytics();
+
+    // Log debug information in development
+    if (process.env.NODE_ENV === "development") {
+      console.log(`Site Version: ${SITE_VERSION}`);
+      console.log("Analytics tracking disabled in development environment");
     }
   }, []);
 
   // Update consent and handle analytics accordingly
   const updateConsent = (newConsent: boolean) => {
     setConsent(newConsent);
-    localStorage.setItem("cookie-consent", newConsent ? "accepted" : "rejected");
 
     // Update analytics services with new consent setting
+    // (This function handles localStorage updates internally)
     updateAnalyticsConsent(newConsent);
   };
 

--- a/src/lib/hooks/useAnalyticsConsent.ts
+++ b/src/lib/hooks/useAnalyticsConsent.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+import {
+  hasAnalyticsConsent,
+  updateAnalyticsConsent,
+  initializeAnalytics,
+} from "../services/analytics";
+
+// Hook to manage analytics consent
+export function useAnalyticsConsent() {
+  const [consent, setConsent] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    // Check for existing consent
+    const hasConsent = hasAnalyticsConsent();
+    setConsent(hasConsent);
+
+    // Initialize analytics with the current consent setting
+    if (typeof window !== "undefined") {
+      initializeAnalytics();
+    }
+  }, []);
+
+  // Update consent and handle analytics accordingly
+  const updateConsent = (newConsent: boolean) => {
+    setConsent(newConsent);
+    localStorage.setItem("cookie-consent", newConsent ? "accepted" : "rejected");
+
+    // Update analytics services with new consent setting
+    updateAnalyticsConsent(newConsent);
+  };
+
+  return {
+    hasConsent: consent,
+    updateConsent,
+  };
+}
+
+export default useAnalyticsConsent;

--- a/src/lib/services/analytics.ts
+++ b/src/lib/services/analytics.ts
@@ -1,0 +1,105 @@
+/**
+ * Analytics service to handle all tracking functionality.
+ * Currently set up for future Google Analytics integration.
+ */
+
+// Check if analytics consent has been given
+export const hasAnalyticsConsent = (): boolean => {
+  return localStorage.getItem("cookie-consent") === "accepted";
+};
+
+// Initialize analytics with proper consent settings
+export const initializeAnalytics = (): void => {
+  const hasConsent = hasAnalyticsConsent();
+
+  // This is where you would initialize Google Analytics with proper consent mode
+  // For now, we just log to console
+  console.log(`Analytics initialized with consent: ${hasConsent}`);
+
+  // Example Google Analytics initialization with consent mode (uncomment when adding GA)
+  /*
+  // Add the script dynamically only when needed
+  if (typeof window !== 'undefined' && !document.getElementById('ga-script')) {
+    const script = document.createElement('script');
+    script.id = 'ga-script';
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=YOUR_GA_MEASUREMENT_ID`;
+    document.head.appendChild(script);
+    
+    window.dataLayer = window.dataLayer || [];
+    function gtag() {
+      dataLayer.push(arguments);
+    }
+    window.gtag = gtag;
+    gtag('js', new Date());
+    
+    // Set default consent settings
+    gtag('consent', 'default', {
+      'analytics_storage': hasConsent ? 'granted' : 'denied',
+      'ad_storage': 'denied', // Always deny ad storage by default
+    });
+    
+    // Initialize with the measurement ID
+    gtag('config', 'YOUR_GA_MEASUREMENT_ID', {
+      'anonymize_ip': true,
+      'send_page_view': hasConsent,
+    });
+  }
+  */
+};
+
+// Update consent settings in analytics platforms
+export const updateAnalyticsConsent = (consent: boolean): void => {
+  // This is where you would update Google Analytics consent settings
+  console.log(`Analytics consent updated: ${consent}`);
+
+  // Example code for updating Google Analytics consent (uncomment when adding GA)
+  /*
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('consent', 'update', {
+      'analytics_storage': consent ? 'granted' : 'denied',
+    });
+  }
+  */
+};
+
+// Track a page view
+export const trackPageView = (path: string): void => {
+  if (!hasAnalyticsConsent()) return;
+
+  // This is where you would send a page view to Google Analytics
+  console.log(`Page view tracked: ${path}`);
+
+  // Example code for tracking pageview in Google Analytics (uncomment when adding GA)
+  /*
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('config', 'YOUR_GA_MEASUREMENT_ID', {
+      'page_path': path,
+    });
+  }
+  */
+};
+
+// Track a custom event
+export const trackEvent = (
+  category: string,
+  action: string,
+  label?: string,
+  value?: number
+): void => {
+  if (!hasAnalyticsConsent()) return;
+
+  // This is where you would send an event to Google Analytics
+  console.log(`Event tracked: ${category} - ${action} - ${label} - ${value}`);
+
+  // Example code for tracking event in Google Analytics (uncomment when adding GA)
+  /*
+  if (typeof window !== 'undefined' && window.gtag) {
+    window.gtag('event', action, {
+      'event_category': category,
+      'event_label': label,
+      'value': value,
+    });
+  }
+  */
+};

--- a/src/lib/services/analytics.ts
+++ b/src/lib/services/analytics.ts
@@ -1,7 +1,8 @@
 /**
  * Analytics service to handle all tracking functionality.
- * Currently set up for future Google Analytics integration.
+ * Integrated with Google Analytics 4.
  */
+import { GA_MEASUREMENT_ID, SITE_VERSION } from "../constants/site";
 
 // Centralized check for browser environment
 export const isBrowser = typeof window !== "undefined";
@@ -9,6 +10,12 @@ export const isBrowser = typeof window !== "undefined";
 // Check if analytics consent has been given
 export const hasAnalyticsConsent = (): boolean => {
   if (!isBrowser) return false;
+
+  // Disable analytics in development environment
+  if (process.env.NODE_ENV === "development") {
+    return false;
+  }
+
   return localStorage.getItem("cookie-consent") === "accepted";
 };
 
@@ -36,36 +43,34 @@ export const initializeAnalytics = (): void => {
   analyticsInitialized = true;
   console.log(`Analytics initialized with consent: ${hasConsent}`);
 
-  // Example Google Analytics initialization with consent mode (uncomment when adding GA)
-  /*
-  // Add the script dynamically only when needed
-  if (!document.getElementById('ga-script')) {
-    const script = document.createElement('script');
-    script.id = 'ga-script';
+  // Add the Google Analytics script dynamically
+  if (!document.getElementById("ga-script")) {
+    const script = document.createElement("script");
+    script.id = "ga-script";
     script.async = true;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=YOUR_GA_MEASUREMENT_ID`;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`;
     document.head.appendChild(script);
-    
+
     window.dataLayer = window.dataLayer || [];
-    function gtag() {
-      dataLayer.push(arguments);
+    function gtag(...args: any[]) {
+      window.dataLayer?.push(args);
     }
     window.gtag = gtag;
-    gtag('js', new Date());
-    
+    gtag("js", new Date());
+
     // Set default consent settings
-    gtag('consent', 'default', {
-      'analytics_storage': 'granted', // We only initialize if consent is given
-      'ad_storage': 'denied', // Always deny ad storage by default
+    gtag("consent", "default", {
+      analytics_storage: "granted", // We only initialize if consent is given
+      ad_storage: "denied", // Always deny ad storage by default
     });
-    
+
     // Initialize with the measurement ID
-    gtag('config', 'YOUR_GA_MEASUREMENT_ID', {
-      'anonymize_ip': true,
-      'send_page_view': true,
+    gtag("config", GA_MEASUREMENT_ID, {
+      anonymize_ip: true,
+      send_page_view: true,
+      site_version: SITE_VERSION, // Track site version as a custom dimension
     });
   }
-  */
 };
 
 // Update consent settings in analytics platforms
@@ -84,14 +89,12 @@ export const updateAnalyticsConsent = (consent: boolean): void => {
     // Handle revoking consent
     analyticsInitialized = false;
 
-    // Example code for updating Google Analytics consent (uncomment when adding GA)
-    /*
+    // Update Google Analytics consent settings if already loaded
     if (window.gtag) {
-      window.gtag('consent', 'update', {
-        'analytics_storage': 'denied',
+      window.gtag("consent", "update", {
+        analytics_storage: "denied",
       });
     }
-    */
   }
 };
 
@@ -101,14 +104,12 @@ export const trackPageView = (path: string): void => {
 
   console.log(`Page view tracked: ${path}`);
 
-  // Example code for tracking pageview in Google Analytics (uncomment when adding GA)
-  /*
+  // Send pageview to Google Analytics
   if (window.gtag) {
-    window.gtag('config', 'YOUR_GA_MEASUREMENT_ID', {
-      'page_path': path,
+    window.gtag("config", GA_MEASUREMENT_ID, {
+      page_path: path,
     });
   }
-  */
 };
 
 // Track a custom event
@@ -122,16 +123,15 @@ export const trackEvent = (
 
   console.log(`Event tracked: ${category} - ${action} - ${label} - ${value}`);
 
-  // Example code for tracking event in Google Analytics (uncomment when adding GA)
-  /*
+  // Send event to Google Analytics
   if (window.gtag) {
-    window.gtag('event', action, {
-      'event_category': category,
-      'event_label': label,
-      'value': value,
+    window.gtag("event", action, {
+      event_category: category,
+      event_label: label,
+      value: value,
+      site_version: SITE_VERSION, // Include site version in all events
     });
   }
-  */
 };
 
 // Web vitals reporting function that respects consent
@@ -140,15 +140,14 @@ export const reportWebVitalsToAnalytics = (metric: any): void => {
 
   console.log(`Web vital reported: ${metric.name} - ${Math.round(metric.value * 100) / 100}`);
 
-  // Example code for tracking web vitals in Google Analytics (uncomment when adding GA)
-  /*
+  // Send web vitals to Google Analytics
   if (window.gtag) {
-    window.gtag('event', 'web-vitals', {
-      event_category: 'Web Vitals',
+    window.gtag("event", "web-vitals", {
+      event_category: "Web Vitals",
       event_label: metric.id,
       value: Math.round(metric.value * 100) / 100,
       non_interaction: true,
+      site_version: SITE_VERSION,
     });
   }
-  */
 };

--- a/src/lib/services/analytics.ts
+++ b/src/lib/services/analytics.ts
@@ -3,23 +3,43 @@
  * Currently set up for future Google Analytics integration.
  */
 
+// Centralized check for browser environment
+export const isBrowser = typeof window !== "undefined";
+
 // Check if analytics consent has been given
 export const hasAnalyticsConsent = (): boolean => {
+  if (!isBrowser) return false;
   return localStorage.getItem("cookie-consent") === "accepted";
 };
 
+// Analytics script status tracking
+let analyticsInitialized = false;
+
 // Initialize analytics with proper consent settings
 export const initializeAnalytics = (): void => {
+  if (!isBrowser) return;
+
   const hasConsent = hasAnalyticsConsent();
 
-  // This is where you would initialize Google Analytics with proper consent mode
-  // For now, we just log to console
+  // Skip initialization if no consent
+  if (!hasConsent) {
+    console.log("Analytics not initialized: user consent not given");
+    return;
+  }
+
+  // Prevent duplicate initialization
+  if (analyticsInitialized) {
+    console.log("Analytics already initialized");
+    return;
+  }
+
+  analyticsInitialized = true;
   console.log(`Analytics initialized with consent: ${hasConsent}`);
 
   // Example Google Analytics initialization with consent mode (uncomment when adding GA)
   /*
   // Add the script dynamically only when needed
-  if (typeof window !== 'undefined' && !document.getElementById('ga-script')) {
+  if (!document.getElementById('ga-script')) {
     const script = document.createElement('script');
     script.id = 'ga-script';
     script.async = true;
@@ -35,14 +55,14 @@ export const initializeAnalytics = (): void => {
     
     // Set default consent settings
     gtag('consent', 'default', {
-      'analytics_storage': hasConsent ? 'granted' : 'denied',
+      'analytics_storage': 'granted', // We only initialize if consent is given
       'ad_storage': 'denied', // Always deny ad storage by default
     });
     
     // Initialize with the measurement ID
     gtag('config', 'YOUR_GA_MEASUREMENT_ID', {
       'anonymize_ip': true,
-      'send_page_view': hasConsent,
+      'send_page_view': true,
     });
   }
   */
@@ -50,29 +70,40 @@ export const initializeAnalytics = (): void => {
 
 // Update consent settings in analytics platforms
 export const updateAnalyticsConsent = (consent: boolean): void => {
-  // This is where you would update Google Analytics consent settings
+  if (!isBrowser) return;
+
+  // Store consent in localStorage
+  localStorage.setItem("cookie-consent", consent ? "accepted" : "rejected");
+
   console.log(`Analytics consent updated: ${consent}`);
 
-  // Example code for updating Google Analytics consent (uncomment when adding GA)
-  /*
-  if (typeof window !== 'undefined' && window.gtag) {
-    window.gtag('consent', 'update', {
-      'analytics_storage': consent ? 'granted' : 'denied',
-    });
+  if (consent) {
+    // Initialize analytics if consent is granted
+    initializeAnalytics();
+  } else {
+    // Handle revoking consent
+    analyticsInitialized = false;
+
+    // Example code for updating Google Analytics consent (uncomment when adding GA)
+    /*
+    if (window.gtag) {
+      window.gtag('consent', 'update', {
+        'analytics_storage': 'denied',
+      });
+    }
+    */
   }
-  */
 };
 
 // Track a page view
 export const trackPageView = (path: string): void => {
-  if (!hasAnalyticsConsent()) return;
+  if (!isBrowser || !hasAnalyticsConsent() || !analyticsInitialized) return;
 
-  // This is where you would send a page view to Google Analytics
   console.log(`Page view tracked: ${path}`);
 
   // Example code for tracking pageview in Google Analytics (uncomment when adding GA)
   /*
-  if (typeof window !== 'undefined' && window.gtag) {
+  if (window.gtag) {
     window.gtag('config', 'YOUR_GA_MEASUREMENT_ID', {
       'page_path': path,
     });
@@ -87,18 +118,36 @@ export const trackEvent = (
   label?: string,
   value?: number
 ): void => {
-  if (!hasAnalyticsConsent()) return;
+  if (!isBrowser || !hasAnalyticsConsent() || !analyticsInitialized) return;
 
-  // This is where you would send an event to Google Analytics
   console.log(`Event tracked: ${category} - ${action} - ${label} - ${value}`);
 
   // Example code for tracking event in Google Analytics (uncomment when adding GA)
   /*
-  if (typeof window !== 'undefined' && window.gtag) {
+  if (window.gtag) {
     window.gtag('event', action, {
       'event_category': category,
       'event_label': label,
       'value': value,
+    });
+  }
+  */
+};
+
+// Web vitals reporting function that respects consent
+export const reportWebVitalsToAnalytics = (metric: any): void => {
+  if (!isBrowser || !hasAnalyticsConsent() || !analyticsInitialized) return;
+
+  console.log(`Web vital reported: ${metric.name} - ${Math.round(metric.value * 100) / 100}`);
+
+  // Example code for tracking web vitals in Google Analytics (uncomment when adding GA)
+  /*
+  if (window.gtag) {
+    window.gtag('event', 'web-vitals', {
+      event_category: 'Web Vitals',
+      event_label: metric.id,
+      value: Math.round(metric.value * 100) / 100,
+      non_interaction: true,
     });
   }
   */

--- a/src/lib/types/window.d.ts
+++ b/src/lib/types/window.d.ts
@@ -8,4 +8,7 @@ interface Window {
       [key: string]: any;
     }
   ) => void;
+
+  // Google Analytics data layer
+  dataLayer?: any[];
 }

--- a/src/lib/types/window.d.ts
+++ b/src/lib/types/window.d.ts
@@ -1,0 +1,11 @@
+// Type declarations for global window object
+interface Window {
+  // Google Analytics
+  gtag?: (
+    command: string,
+    action: string,
+    params?: {
+      [key: string]: any;
+    }
+  ) => void;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,6 @@ import { routeTree } from "./routeTree.gen";
 
 import "./styles.css";
 import reportWebVitals from "./reportWebVitals.ts";
-import { hasAnalyticsConsent } from "./lib/services/analytics";
 
 // Initial theme setup (later handled by ThemeSwitcher component)
 const initializeTheme = () => {
@@ -63,12 +62,5 @@ if (rootElement && !rootElement.innerHTML) {
   );
 }
 
-// Only initialize web vitals reporting if consent is given
-if (hasAnalyticsConsent()) {
-  reportWebVitals();
-} else {
-  // Still allow performance tracking locally, but don't send to analytics
-  reportWebVitals(() => {
-    // No-op - this prevents sending analytics data
-  });
-}
+// Initialize web vitals reporting (it will check for consent internally)
+reportWebVitals();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,7 @@ import { routeTree } from "./routeTree.gen";
 
 import "./styles.css";
 import reportWebVitals from "./reportWebVitals.ts";
+import { hasAnalyticsConsent } from "./lib/services/analytics";
 
 // Initial theme setup (later handled by ThemeSwitcher component)
 const initializeTheme = () => {
@@ -62,7 +63,12 @@ if (rootElement && !rootElement.innerHTML) {
   );
 }
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+// Only initialize web vitals reporting if consent is given
+if (hasAnalyticsConsent()) {
+  reportWebVitals();
+} else {
+  // Still allow performance tracking locally, but don't send to analytics
+  reportWebVitals(() => {
+    // No-op - this prevents sending analytics data
+  });
+}

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -7,6 +7,38 @@ const reportWebVitals = (onPerfEntry?: () => void) => {
       onLCP(onPerfEntry);
       onTTFB(onPerfEntry);
     });
+  } else {
+    // Check consent before sending analytics data to a service
+    const hasConsent = localStorage.getItem("cookie-consent") === "accepted";
+
+    if (hasConsent) {
+      // This would be where you'd send analytics to a third-party service
+      // For example, Google Analytics
+      console.log("Web vitals could be sent to analytics service");
+
+      // When Google Analytics is added, you would uncomment this:
+      /*
+      import("web-vitals").then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
+        const sendToAnalytics = (metric) => {
+          // Send to Google Analytics or other service
+          if (window.gtag) {
+            window.gtag('event', 'web-vitals', {
+              event_category: 'Web Vitals',
+              event_label: metric.id,
+              value: Math.round(metric.value * 100) / 100,
+              non_interaction: true,
+            });
+          }
+        };
+        
+        onCLS(sendToAnalytics);
+        onINP(sendToAnalytics);
+        onFCP(sendToAnalytics);
+        onLCP(sendToAnalytics);
+        onTTFB(sendToAnalytics);
+      });
+      */
+    }
   }
 };
 

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,45 +1,35 @@
-const reportWebVitals = (onPerfEntry?: () => void) => {
-  if (onPerfEntry && onPerfEntry instanceof Function) {
-    import("web-vitals").then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
-      onCLS(onPerfEntry);
-      onINP(onPerfEntry);
-      onFCP(onPerfEntry);
-      onLCP(onPerfEntry);
-      onTTFB(onPerfEntry);
-    });
-  } else {
-    // Check consent before sending analytics data to a service
-    const hasConsent = localStorage.getItem("cookie-consent") === "accepted";
+import { isBrowser, hasAnalyticsConsent } from "./lib/services/analytics";
 
-    if (hasConsent) {
-      // This would be where you'd send analytics to a third-party service
-      // For example, Google Analytics
-      console.log("Web vitals could be sent to analytics service");
+const reportWebVitals = () => {
+  // Early returns if not in browser or no consent given
+  if (!isBrowser) return;
+  if (!hasAnalyticsConsent()) return;
+
+  // Only import and setup web-vitals if we have consent
+  import("web-vitals").then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
+    const sendToAnalytics = (metric: any) => {
+      // Log to console for now
+      console.log(`Web vital: ${metric.name} - ${Math.round(metric.value * 100) / 100}`);
 
       // When Google Analytics is added, you would uncomment this:
       /*
-      import("web-vitals").then(({ onCLS, onINP, onFCP, onLCP, onTTFB }) => {
-        const sendToAnalytics = (metric) => {
-          // Send to Google Analytics or other service
-          if (window.gtag) {
-            window.gtag('event', 'web-vitals', {
-              event_category: 'Web Vitals',
-              event_label: metric.id,
-              value: Math.round(metric.value * 100) / 100,
-              non_interaction: true,
-            });
-          }
-        };
-        
-        onCLS(sendToAnalytics);
-        onINP(sendToAnalytics);
-        onFCP(sendToAnalytics);
-        onLCP(sendToAnalytics);
-        onTTFB(sendToAnalytics);
-      });
+      if (window.gtag) {
+        window.gtag('event', 'web-vitals', {
+          event_category: 'Web Vitals',
+          event_label: metric.id,
+          value: Math.round(metric.value * 100) / 100,
+          non_interaction: true,
+        });
+      }
       */
-    }
-  }
+    };
+
+    onCLS(sendToAnalytics);
+    onINP(sendToAnalytics);
+    onFCP(sendToAnalytics);
+    onLCP(sendToAnalytics);
+    onTTFB(sendToAnalytics);
+  });
 };
 
 export default reportWebVitals;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,11 +3,14 @@ import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
 
 import Header from "../components/Header";
 import Footer from "../components/Footer";
+import CookieBanner from "../components/CookieBanner";
+import useAnalyticsConsent from "../lib/hooks/useAnalyticsConsent";
 
 export const Route = createRootRoute({
   component: () => {
     const router = useRouterState();
     const isLandingPage = router.location.pathname === "/";
+    const { updateConsent } = useAnalyticsConsent();
 
     return (
       <>
@@ -24,6 +27,12 @@ export const Route = createRootRoute({
             </main>
           </div>
           <Footer />
+
+          {/* Cookie consent banner */}
+          <CookieBanner
+            onAccept={() => updateConsent(true)}
+            onReject={() => updateConsent(false)}
+          />
         </div>
         <TanStackRouterDevtools />
       </>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,6 +1,6 @@
 import { Outlet, createRootRoute, useRouterState } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import Header from "../components/Header";
 import Footer from "../components/Footer";
@@ -14,6 +14,7 @@ export const Route = createRootRoute({
     const router = useRouterState();
     const isLandingPage = router.location.pathname === "/";
     const { updateConsent, hasConsent } = useAnalyticsConsent();
+    const [bannerVisible, setBannerVisible] = useState(false);
 
     // Track page views when route changes
     useEffect(() => {
@@ -28,7 +29,9 @@ export const Route = createRootRoute({
     return (
       <>
         <div
-          className={`px-4 sm:px-6 flex flex-col min-h-screen ${isLandingPage ? "bg-watercolor-flipped" : ""} handwriting-enabled`}
+          className={`px-4 sm:px-6 flex flex-col min-h-screen ${
+            isLandingPage ? "bg-watercolor-flipped" : ""
+          } handwriting-enabled`}
         >
           {/* Header is fixed, so it's outside the content flow */}
           <Header />
@@ -41,12 +44,25 @@ export const Route = createRootRoute({
           </div>
           <Footer />
 
-          {/* Cookie consent banner */}
+          {/* Spacer div that takes up space when banner is visible */}
+          {bannerVisible && <div style={{ height: "80px" }} aria-hidden="true" />}
+        </div>
+
+        {/* Cookie consent banner - fixed position */}
+        <div className="fixed bottom-0 left-0 right-0 z-50">
           <CookieBanner
-            onAccept={() => updateConsent(true)}
-            onReject={() => updateConsent(false)}
+            onAccept={() => {
+              updateConsent(true);
+              setBannerVisible(false);
+            }}
+            onReject={() => {
+              updateConsent(false);
+              setBannerVisible(false);
+            }}
+            onVisibilityChange={setBannerVisible}
           />
         </div>
+
         <TanStackRouterDevtools />
       </>
     );

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,16 +1,29 @@
 import { Outlet, createRootRoute, useRouterState } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools";
+import { useEffect } from "react";
 
 import Header from "../components/Header";
 import Footer from "../components/Footer";
 import CookieBanner from "../components/CookieBanner";
 import useAnalyticsConsent from "../lib/hooks/useAnalyticsConsent";
+import { trackPageView } from "../lib/services/analytics";
+import { SITE_VERSION } from "../lib/constants/site";
 
 export const Route = createRootRoute({
   component: () => {
     const router = useRouterState();
     const isLandingPage = router.location.pathname === "/";
-    const { updateConsent } = useAnalyticsConsent();
+    const { updateConsent, hasConsent } = useAnalyticsConsent();
+
+    // Track page views when route changes
+    useEffect(() => {
+      // Only track if user has given consent
+      if (hasConsent) {
+        const path = router.location.pathname;
+        trackPageView(path);
+        console.log(`Page view: ${path} (Site Version: ${SITE_VERSION})`);
+      }
+    }, [router.location.pathname, hasConsent]);
 
     return (
       <>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -7,7 +7,7 @@ export const Route = createFileRoute("/")({
 
 function LandingPage() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-136px)] mt-0 md:-mt-16 py-8 md:py-0 overflow-hidden">
+    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-200px)] mt-0 md:-mt-16 py-8 md:py-0 overflow-hidden">
       <div className="text-center flex flex-col items-center w-full px-4">
         <div className="mb-6 sm:mb-8 md:mb-10flex justify-center">
           <Logo


### PR DESCRIPTION
This PR sets up a cookie consent banner with consent tracked in local storage. Currently just a binary accept/reject since the site is functional without cookies, which are just for tracking. We're using the same GA property as the current mirascope website, but with a site version of "1.1" as a custom dimension for tracking. Will add PostHog in a separate PR once I have permissions.