### PR TITLE
feat: add robots.txt and sitemap generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__/
 
 # Generated files
 public/static/
+public/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,7 @@
-# https://www.robotstxt.org/robotstxt.html
+# robots.txt for mirascope.com
 User-agent: *
-Disallow:
+Allow: /
+Disallow: /assets/blog/  # No need to index blog assets directly
+
+# Sitemap location
+Sitemap: https://mirascope.com/sitemap.xml


### PR DESCRIPTION
• Update robots.txt with appropriate directives
• Add sitemap.xml generation to preprocess-content script • Add pricing to static routes
• Use daily change frequency for all pages
• Exclude sitemap.xml from git tracking

🤖 Generated with [Claude Code](https://claude.ai/code)