### PR TITLE
refactor: tools extract route structure from tanstack

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "start": "bun --bun vite --port 3000",
     "preprocess-content": "bun run scripts/preprocess-content.ts",
     "fetch-github-stats": "bun run --bun scripts/fetch-github-stats.ts",
+    "enumerate-routes": "bun run scripts/enumerate-routes.ts",
     "prebuild": "bun run preprocess-content",
     "build": "bun run --bun vite build && bun run tsc",
     "serve": "bun --bun vite preview",

--- a/scripts/enumerate-routes.ts
+++ b/scripts/enumerate-routes.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env bun
+/**
+ * Test script for router-utils.ts
+ * This script will enumerate all routes detected by the router utility
+ * and display them in different categories
+ */
+import {
+  getStaticRoutes,
+  getBlogRoutes,
+  getDocsRoutes,
+  getAllRoutes,
+} from "../src/lib/router-utils";
+
+// ANSI color codes for better output
+const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const BLUE = "\x1b[34m";
+const MAGENTA = "\x1b[35m";
+const CYAN = "\x1b[36m";
+
+// Print a section header
+function printHeader(title: string, color: string = BLUE): void {
+  console.log("\n" + color + "=".repeat(50) + RESET);
+  console.log(color + ` ${title} ` + RESET);
+  console.log(color + "=".repeat(50) + RESET);
+}
+
+// Print a list of routes
+function printRoutes(routes: string[], color: string = RESET): void {
+  if (routes.length === 0) {
+    console.log("  No routes found");
+    return;
+  }
+
+  routes.forEach((route, index) => {
+    console.log(`  ${color}${index + 1}. ${route}${RESET}`);
+  });
+  console.log(`\n  Total: ${color}${routes.length} routes${RESET}`);
+}
+
+// Main function to run tests
+async function main() {
+  printHeader("TanStack Router Utils Test", CYAN);
+  console.log("Testing the router-utils.ts utility to verify route extraction\n");
+
+  try {
+    // Test static routes extraction
+    printHeader("Static Routes (extracted from TanStack Router)", GREEN);
+    const staticRoutes = getStaticRoutes();
+    printRoutes(staticRoutes, GREEN);
+
+    // Test blog routes extraction
+    printHeader("Blog Routes (from posts list)", YELLOW);
+    const blogRoutes = await getBlogRoutes();
+    printRoutes(blogRoutes, YELLOW);
+
+    // Test docs routes extraction
+    printHeader("Docs Routes (from _meta.ts)", MAGENTA);
+    const docsRoutes = getDocsRoutes();
+    printRoutes(docsRoutes, MAGENTA);
+
+    // Test all routes combined
+    printHeader("All Routes Combined", CYAN);
+    const allRoutes = await getAllRoutes();
+    printRoutes(allRoutes, CYAN);
+
+    // Look for potential duplicates or inconsistencies
+    printHeader("Potential Issues", YELLOW);
+
+    // Check if there are any static routes in docs routes
+    const staticInDocs = staticRoutes.filter(
+      (route) => docsRoutes.includes(route) && route.startsWith("/docs")
+    );
+
+    if (staticInDocs.length > 0) {
+      console.log(
+        `${YELLOW}Found ${staticInDocs.length} static routes that overlap with docs routes:${RESET}`
+      );
+      staticInDocs.forEach((route) => console.log(`  - ${route}`));
+    } else {
+      console.log(`${GREEN}No overlaps found between static and docs routes${RESET}`);
+    }
+
+    console.log("\n" + CYAN + "=".repeat(50) + RESET);
+    console.log(`${GREEN}Test completed successfully!${RESET}`);
+  } catch (error) {
+    console.error(`\n${YELLOW}Error testing router utils:${RESET}`, error);
+    process.exit(1);
+  }
+}
+
+// Run the main function
+main().catch((error) => {
+  console.error("Unhandled error:", error);
+  process.exit(1);
+});

--- a/src/lib/router-utils.ts
+++ b/src/lib/router-utils.ts
@@ -1,0 +1,162 @@
+// scripts/lib/router-utils.ts
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import type { PostMeta } from "./mdx";
+import { getAllDocs } from "../docs/_meta";
+
+// Base URL for the site
+export const SITE_URL = "https://mirascope.com";
+
+// Exclude these static routes as they auto-redirect to other pages
+const ROUTES_TO_EXCLUDE = ["/docs/", "/terms/"];
+
+// Get the project root directory
+export function getProjectRoot(): string {
+  // Get the directory name for the current module
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  // Project root directory (2 levels up from src/lib)
+  return path.join(__dirname, "..", "..");
+}
+
+// Get path to posts list json
+export function getPostsListPath(): string {
+  return path.join(getProjectRoot(), "public", "static", "posts-list.json");
+}
+
+/**
+ * Extract static routes from TanStack Router's generated route tree file
+ * This avoids having to duplicate route definitions
+ */
+export function getStaticRoutes(): string[] {
+  // Read the routeTree.gen.ts file to extract routes
+  const routeTreePath = path.join(getProjectRoot(), "src", "routeTree.gen.ts");
+  const routeTreeContent = fs.readFileSync(routeTreePath, "utf-8");
+
+  // Extract routes from the manifest section
+  const manifestMatch = routeTreeContent.match(
+    /ROUTE_MANIFEST_START\s*(\{[\s\S]*?\})\s*ROUTE_MANIFEST_END/
+  );
+  if (manifestMatch && manifestMatch[1]) {
+    try {
+      const manifest = JSON.parse(manifestMatch[1]);
+
+      if (manifest.routes) {
+        // Extract all routes from the manifest
+        const routes = Object.keys(manifest.routes);
+
+        // Filter out the root and dynamic routes
+        return routes
+          .filter(
+            (route) =>
+              route !== "__root__" &&
+              !route.includes("$") &&
+              !ROUTES_TO_EXCLUDE.some((exclude) => route == exclude)
+          )
+          .map((route) => {
+            // Normalize trailing slashes to match real URLs
+            if (route.endsWith("/") && route !== "/") {
+              return route.slice(0, -1);
+            }
+            return route;
+          })
+          .sort();
+      }
+    } catch (error) {
+      console.warn("Failed to parse route manifest, falling back to regex extraction");
+    }
+  }
+
+  // Fallback to the previous regex approach if manifest extraction fails
+  const staticRoutes: string[] = [];
+
+  // Match all path entries in the FileRoutesByPath interface
+  const pathRegex = /\s+'\/[^']*':\s+{/g;
+  let match;
+
+  while ((match = pathRegex.exec(routeTreeContent)) !== null) {
+    // Extract and clean up the path
+    let route = match[0].trim().split("'")[1];
+
+    // Skip dynamic routes for static generation
+    if (route.includes("$")) {
+      continue;
+    }
+
+    // Normalize trailing slashes to match TanStack behavior
+    // TanStack path: '/blog/' but actual URL is '/blog'
+    if (route.endsWith("/") && route !== "/") {
+      route = route.slice(0, -1);
+    }
+
+    staticRoutes.push(route);
+  }
+
+  return staticRoutes.sort();
+}
+
+/**
+ * Get blog post routes from the posts list
+ */
+export async function getBlogRoutes(): Promise<string[]> {
+  const postsListPath = getPostsListPath();
+  if (!fs.existsSync(postsListPath)) {
+    console.warn("Blog posts list not found at:", postsListPath);
+    return [];
+  }
+
+  try {
+    const postsList: PostMeta[] = JSON.parse(fs.readFileSync(postsListPath, "utf8"));
+    return postsList.map((post) => `/blog/${post.slug}`).sort();
+  } catch (error) {
+    console.warn("Failed to load blog posts list:", error);
+    return [];
+  }
+}
+
+/**
+ * Get doc routes
+ */
+export function getDocsRoutes(): string[] {
+  const allDocs = getAllDocs();
+  return allDocs
+    .map((doc) => {
+      if (doc.path === "index") {
+        return `/docs/${doc.product}`;
+      } else {
+        return `/docs/${doc.product}/${doc.path}`;
+      }
+    })
+    .sort();
+}
+
+/**
+ * Get all routes (static + blogs + docs)
+ */
+export async function getAllRoutes(): Promise<string[]> {
+  const staticRoutes = getStaticRoutes();
+  const blogRoutes = await getBlogRoutes();
+  const docRoutes = getDocsRoutes();
+
+  // Combine all routes and remove duplicates
+  const allRoutes = [...staticRoutes, ...blogRoutes, ...docRoutes];
+  return [...new Set(allRoutes)].sort();
+}
+
+/**
+ * Get posts with metadata
+ */
+export async function getBlogPostsWithMeta(): Promise<PostMeta[]> {
+  const postsListPath = getPostsListPath();
+  if (!fs.existsSync(postsListPath)) {
+    console.warn("Blog posts list not found at:", postsListPath);
+    return [];
+  }
+
+  try {
+    return JSON.parse(fs.readFileSync(postsListPath, "utf8"));
+  } catch (error) {
+    console.warn("Failed to load blog posts list:", error);
+    return [];
+  }
+}


### PR DESCRIPTION
For preprocessing build (and, in future, generating social images), we can automatically track all the routes in tanstack. This ensure we won't add new pages and forget to include them in sitemap, etc.