### PR TITLE
fix: tests pass even pre-build

### DIFF
--- a/scripts/preprocess-content.ts
+++ b/scripts/preprocess-content.ts
@@ -240,7 +240,7 @@ async function generateSitemap(verbose = true): Promise<void> {
   if (verbose) console.log("Generating sitemap.xml...");
 
   // Get all routes using our centralized utility
-  const uniqueRoutes = await getAllRoutes();
+  const uniqueRoutes = getAllRoutes();
 
   // Get blog posts metadata for setting lastmod dates
   const postsList = await getBlogPostsWithMeta();


### PR DESCRIPTION
The router-utils were depending on built content for enumerating all routes, gave it a fallback