### PR TITLE
chore: update groq model references to llama-3.3-70b-versatile

### DIFF
--- a/content/doc/mirascope/guides/agents/qwant-search-agent-with-sources.mdx
+++ b/content/doc/mirascope/guides/agents/qwant-search-agent-with-sources.mdx
@@ -167,7 +167,7 @@ Now, let's implement the function to determine the most appropriate search type:
 
 ```python
 @throttled_groq_call(
-    "llama-3.2-90b-text-preview", response_model=SearchType, json_mode=True
+    "llama-3.3-70b-versatile", response_model=SearchType, json_mode=True
 )
 @prompt_template(
     """
@@ -279,7 +279,7 @@ Now, let's implement the functions to process the search results and extract the
 
 
 ```python
-@groq_call("llama-3.2-90b-text-preview")
+@groq_call("llama-3.3-70b-versatile")
 @prompt_template(
     """
 SYSTEM:
@@ -302,7 +302,7 @@ def search(question: str, search_results: dict[str, str]) -> str:
 
 
 @throttled_groq_call(
-    "llama-3.2-90b-text-preview", response_model=SearchResponse, json_mode=True
+    "llama-3.3-70b-versatile", response_model=SearchResponse, json_mode=True
 )  # Changed response_model from SearchType to SearchResponse
 @prompt_template(
     """

--- a/content/doc/mirascope/guides/more-advanced/o1-style-thinking.mdx
+++ b/content/doc/mirascope/guides/more-advanced/o1-style-thinking.mdx
@@ -106,7 +106,7 @@ class COTResult(BaseModel):
     )
 
 
-@groq.call("llama-3.1-70b-versatile", json_mode=True, response_model=COTResult)
+@groq.call("llama-3.3-70b-versatile", json_mode=True, response_model=COTResult)
 def cot_step(prompt: str, step_number: int, previous_steps: str) -> str:
     return f"""
     You are an expert AI assistant that explains your reasoning step by step.
@@ -134,7 +134,7 @@ def cot_step(prompt: str, step_number: int, previous_steps: str) -> str:
     """
 
 
-@groq.call("llama-3.1-70b-versatile")
+@groq.call("llama-3.3-70b-versatile")
 def final_answer(prompt: str, reasoning: str) -> str:
     return f"""
     Based on the following chain of reasoning, provide a final answer to the question.

--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -62,7 +62,7 @@ export const providerDefaults: Record<
   },
   groq: {
     displayName: "Groq",
-    defaultModel: "llama-3.1-70b-versatile",
+    defaultModel: "llama-3.3-70b-versatile",
   },
   cohere: {
     displayName: "Cohere",


### PR DESCRIPTION
Stays in sync with mirascope/mirascope#949

Note: no autogenerated file updates because we don't currently generate committed snippets for all the providers (as it doesn't add addl. typechecking safety) 