### PR TITLE
feat: tune text shadows on medium headers

### DIFF
--- a/src/components/routes/home/LilypadBlock.tsx
+++ b/src/components/routes/home/LilypadBlock.tsx
@@ -19,10 +19,9 @@ export const LilypadBlock = ({ onScrollToTop }: LilypadBlockProps) => {
         lines={["Spin up your data flywheel", "with one line of code"]}
         element="h2"
         fontSize="clamp(1.5rem, 5vw, 3rem)"
-        className="mb-6 text-center text-white"
+        className="text-shadow-medium mb-6 text-center text-white"
         lineClassName="font-bold"
         lineSpacing="mb-2"
-        textShadow={true}
       />
       <div className="mb-2 w-full max-w-3xl">
         <div className="bg-background/60 mb-2 w-full rounded-md">

--- a/src/components/routes/home/MirascopeBlock.tsx
+++ b/src/components/routes/home/MirascopeBlock.tsx
@@ -36,10 +36,9 @@ book: Book = extract_book(text) # [!code highlight]`;
         lines={["LLM abstractions that", "aren't obstructions"]}
         element="h2"
         fontSize="clamp(1.5rem, 5vw, 3rem)"
-        className="mb-6 text-center text-white"
+        className="text-shadow-medium mb-6 text-center text-white"
         lineClassName="font-bold"
         lineSpacing="mb-2"
-        textShadow={true}
       />
       <div className="bg-background/60 mb-2 w-full max-w-3xl rounded-md">
         <ProviderTabbedSection

--- a/src/styles.css
+++ b/src/styles.css
@@ -133,11 +133,18 @@ pre,
   font-size: 1rem !important;
 }
 
-/* Landing page text shadow */
+/* Landing page text shadow - default for larger hero text */
 .landing-page-text-shadow {
   text-shadow:
     0 2px 6px rgba(0, 0, 0, 0.3),
     0 4px 14px rgba(0, 0, 0, 0.2);
+}
+
+/* Medium text shadow - create a utility class for medium-sized text */
+.text-shadow-medium {
+  text-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.2),
+    0 2px 7px rgba(0, 0, 0, 0.15);
 }
 
 /* Landing page hover text shadow - lighter for accent color text */


### PR DESCRIPTION
addresses safari-specific rendering inconsistency