### PR TITLE
release meta & seo improvements (and other fixes)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,33 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./scripts/typecheck-snippets.sh:*)",
+      "Bash(bun run:*)",
+      "Bash(bun test:*)",
+      "Bash(find:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr view:*)",
+      "Bash(git checkout:*)",
+      "Bash(git fetch:*)",
+      "Bash(git reset:*)",
+      "Bash(grep:*)",
+      "Bash(ls:*)",
+      "Bash(mkdir:*)",
+      "Bash(node:*)",
+      "Bash(npm install:*)",
+      "Bash(npm run build:*)",
+      "Bash(npm run typecheck:*)",
+      "Bash(npm run update-snippets:*)",
+      "Bash(npx tsc:*)",
+      "WebFetchTool(domain:bun.sh)",
+      "WebFetchTool(domain:developers.cloudflare.com)",
+      "WebFetchTool(domain:mirascope.com)",
+      "WebFetchTool(domain:mkdocstrings.github.io)",
+      "WebFetchTool(domain:tanstack.com)",
+      "WebFetchTool(domain:vite.dev)",
+      "Bash(rg:*)",
+      "WebFetch(domain:tanstack.com)"
+    ],
+    "deny": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ public/sitemap.xml
 public/social-cards/
 public/seo-metadata.json
 .extracted-snippets/
+debug-output
 
 # API docs generation repositories
 .api-generation-repos/

--- a/content/blog/llm-agents.mdx
+++ b/content/blog/llm-agents.mdx
@@ -37,7 +37,7 @@ In this article, we explain how LLM agents work, their core components and use c
 
 ## Components of an LLM Agent
 
-[LLM agents](/docs/mirascope/learn/agents/?h=agents) are built around four key parts that work together to enable reasoning, planning, and execution.
+[LLM agents](/docs/mirascope/learn/agents) are built around four key parts that work together to enable reasoning, planning, and execution.
 
 These components include:
 

--- a/content/blog/prompt-evaluation.mdx
+++ b/content/blog/prompt-evaluation.mdx
@@ -621,7 +621,7 @@ Mirascope’s flexible and modular architecture lets you pick and choose what to
 
 This especially means not having to deal with the overhead of complex abstractions found in more comprehensive [LLM frameworks](/blog/llm-frameworks/).
 
-Our toolkit follows developer best practices by making the LLM call the [central primitive](/blog/engineers-should-handle-prompting-llms/?h=why+cod) around which everything, including the prompt, is versioned. This cuts down on boilerplate and prevents drift, and better ensures your prompts are type-safe and effectively versioned.
+Our toolkit follows developer best practices by making the LLM call the [central primitive](/blog/engineers-should-handle-prompting-llms) around which everything, including the prompt, is versioned. This cuts down on boilerplate and prevents drift, and better ensures your prompts are type-safe and effectively versioned.
 
 Below, we walk you through an example of evaluating prompts for an LLM  hiring assistant. The goal is to ensure the prompts guide the assistant in producing accurate, unbiased responses tailored to specific job roles.
 

--- a/content/docs/mirascope/guides/agents/web-search-agent.mdx
+++ b/content/docs/mirascope/guides/agents/web-search-agent.mdx
@@ -45,7 +45,7 @@ We'll use two pre-made tools from `mirascope.tools`:
 
 The `DuckDuckGoSearch` tool provides search results with URLs while `ParseURLContent` handles the content extraction. We save our search results into `search_history` to provide context for future searches.
 
-For a full list of available pre-made tools and their capabilities, check out the <a href="/docs/mirascope/learn/tools/#pre-made-tools\">Pre-made Tools documentation</a>.
+For a full list of available pre-made tools and their capabilities, check out the <a href="/docs/mirascope/learn/tools/#pre-made-tools">Pre-made Tools documentation</a>.
 
 ## Add Q&A Functionality
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "optimize-images": "bun run scripts/optimize-images.ts",
     "prebuild": "bun run preprocess-content",
     "build": "bun run --bun vite build && bun run prerender",
-    "build:full": "bun run prebuild && bun run generate-og-images && bun run --bun vite build && bun run optimize-images && bun run prerender && bun run postbuild",
+    "build:full": "bun run prebuild && bun run --bun vite build && bun run generate-og-images && bun run optimize-images && bun run prerender && bun run postbuild",
     "postbuild": "pagefind --site dist --output-path dist/_pagefind --root-selector '[data-pagefind-body=\"true\"]' --",
     "serve": "bun scripts/serve-static.js",
     "test": "bun test",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "optimize-images": "bun run scripts/optimize-images.ts",
     "prebuild": "bun run preprocess-content",
     "build": "bun run --bun vite build && bun run prerender",
-    "build:full": "bun run prebuild && bun run --bun vite build && bun run generate-og-images && bun run optimize-images && bun run prerender && bun run postbuild",
+    "build:full": "bun run prebuild && bun run generate-og-images && bun run --bun vite build && bun run optimize-images && bun run prerender && bun run postbuild",
     "postbuild": "pagefind --site dist --output-path dist/_pagefind --root-selector '[data-pagefind-body=\"true\"]' --",
     "serve": "bun scripts/serve-static.js",
     "test": "bun test",

--- a/public/dev/social-card.html
+++ b/public/dev/social-card.html
@@ -29,7 +29,7 @@
     }
 
     // Function to update the social card
-    function updateSocialCard(title) {
+    function updateSocialCard(title, product = 'mirascope') {
       // Update the content
       document.getElementById('title-element').textContent = title;
 
@@ -39,6 +39,31 @@
 
       document.getElementById('title-element').style.fontSize = titleFontSize;
       document.getElementById('title-element').style.lineHeight = lineHeight;
+
+      // Update product branding
+      updateProductBranding(product);
+    }
+
+    // Function to update product branding (logo and text)
+    function updateProductBranding(product) {
+      const logoImg = document.getElementById('logo-img');
+      const logoText = document.getElementById('logo-text');
+      
+      if (product === 'lilypad') {
+        // Use data URL if available (for Puppeteer), otherwise use regular path (for browser)
+        const lilypadLogoUrl = window.LOGO_DATA_URLS?.['/assets/branding/lilypad-logo.svg'] || '/assets/branding/lilypad-logo.svg';
+        logoImg.src = lilypadLogoUrl;
+        logoImg.alt = 'Lilypad Logo';
+        logoText.textContent = 'Lilypad';
+        logoText.style.color = '#409b45'; // Lilypad green
+      } else {
+        // Use data URL if available (for Puppeteer), otherwise use regular path (for browser)
+        const mirascopeLogoUrl = window.LOGO_DATA_URLS?.['/assets/branding/mirascope-logo.svg'] || '/assets/branding/mirascope-logo.svg';
+        logoImg.src = mirascopeLogoUrl;
+        logoImg.alt = 'Mirascope Logo';
+        logoText.textContent = 'Mirascope';
+        logoText.style.color = '#6366f1'; // Mirascope purple
+      }
     }
 
     // Expose the update function globally for iframe and Puppeteer communication
@@ -47,10 +72,10 @@
     // Check for URL parameters that might be passed to this template
     const urlParams = new URLSearchParams(window.location.search);
     const titleParam = urlParams.get('title');
-    const descriptionParam = urlParams.get('description');
+    const productParam = urlParams.get('product');
 
-    if (titleParam) {
-      updateSocialCard(titleParam);
+    if (titleParam && productParam) {
+      updateSocialCard(titleParam, productParam);
     }
   </script>
   <style>
@@ -116,7 +141,7 @@
 
     .logo-inner {
       position: relative;
-      padding: 5px 30px;
+      padding: 15px 42px;
     }
 
     .logo-bg {
@@ -140,7 +165,7 @@
     }
 
     .logo-img {
-      width: 48px;
+      height: 44px;
       margin-right: 12px;
       margin-bottom: 6px;
     }
@@ -195,8 +220,8 @@
         <div class="logo-inner">
           <div class="logo-bg torn-paper-effect"></div>
           <div class="logo-content">
-            <img src="/assets/branding/mirascope-logo.svg" alt="Mirascope Logo" class="logo-img">
-            <span class="logo-text">Mirascope</span>
+            <img id="logo-img" src="/assets/branding/mirascope-logo.svg" alt="Mirascope Logo" class="logo-img">
+            <span id="logo-text" class="logo-text">Mirascope</span>
           </div>
         </div>
       </div>

--- a/scripts/generate-og-images.ts
+++ b/scripts/generate-og-images.ts
@@ -1,15 +1,4 @@
 #!/usr/bin/env bun
-/**
- * Unified social media generation tool
- *
- * Supports:
- * --all                  : Regenerate all metadata and images
- * --update               : Update metadata and regenerate images only for changed routes
- * --regenerate-images    : Regenerate all images using existing metadata
- * --only <path>          : Update specific route only
- * --check                : Check for missing metadata or images
- * --help                 : Show help
- */
 
 import { colorize, coloredLog, printHeader } from "./lib/terminal";
 import { generateOgImages } from "./lib/social-card-generator";
@@ -71,11 +60,19 @@ function saveMetadataToFile(metadata: RouteMetadata[], verbose = false): string 
  * Main function
  */
 async function main() {
-  printHeader("SOCIAL CARD GENERATION", "magenta");
+  // Check for test flag
+  const isTestMode = process.argv.includes("--test");
 
-  // Get all routes
+  if (isTestMode) {
+    printHeader("TEST MODE SOCIAL CARD GENERATION", "magenta");
+    coloredLog("Generating cards for test routes only", "yellow");
+  } else {
+    printHeader("SOCIAL CARD GENERATION", "magenta");
+  }
+
+  // Get routes (either all or test routes)
   const routesStart = performance.now();
-  const allRoutes = await getAllRoutes();
+  const allRoutes = isTestMode ? ["/", "/pricing"] : await getAllRoutes();
   coloredLog(
     `Found ${allRoutes.length} routes (${((performance.now() - routesStart) / 1000).toFixed(2)}s)`,
     "cyan"
@@ -99,12 +96,14 @@ async function main() {
   );
 
   // Save full metadata (with descriptions) to file
-  saveMetadataToFile(metadataList, true);
+  if (!isTestMode) {
+    saveMetadataToFile(metadataList, true);
+  }
 
   // Generate social card images (only needs route and title)
   printHeader("IMAGE GENERATION", "blue");
   const imagesStart = performance.now();
-  await generateOgImages(metadataList);
+  await generateOgImages(metadataList, true, isTestMode);
   const imagesTime = (performance.now() - imagesStart) / 1000;
   coloredLog(`Image generation complete (${imagesTime.toFixed(2)}s)`, "green");
 
@@ -112,6 +111,9 @@ async function main() {
   const totalTime = (performance.now() - routesStart) / 1000;
   printHeader("PROCESS COMPLETE", "green");
   coloredLog(`Total processing time: ${totalTime.toFixed(2)}s`, "cyan");
+  if (isTestMode) {
+    coloredLog("Test mode complete. Images saved to debug-output/.", "yellow");
+  }
 }
 
 // Run the main function

--- a/src/components/core/layout/AppLayout.tsx
+++ b/src/components/core/layout/AppLayout.tsx
@@ -246,7 +246,7 @@ AppLayout.LeftSidebar = ({ children, className, collapsible = true }: SidebarPro
             !isOpen && "translate-x-[-110%] md:translate-x-0", // Hidden on mobile when closed
             // Size and appearance
             "w-[calc(100vw-20px)] max-w-xs sm:w-[85vw] md:w-64",
-            "rounded-r-md md:border-r",
+            "rounded-r-md",
             // Always display on desktop, unless non-collapsible on mobile
             !collapsible && "md:block",
             // Animation

--- a/src/components/core/meta/PageMeta.tsx
+++ b/src/components/core/meta/PageMeta.tsx
@@ -1,14 +1,12 @@
-import { useMemo } from "react";
 import { BASE_URL, PRODUCT_CONFIGS } from "@/src/lib/constants/site";
 import { useRouterState } from "@tanstack/react-router";
-import { routeToFilename } from "@/src/lib/utils";
+import { routeToFilename, canonicalizePath } from "@/src/lib/utils";
 import { RouteMeta } from "./RouteMeta";
 import type { ProductName } from "@/src/lib/content/spec";
 export interface PageMetaProps {
   title?: string;
   description?: string;
   image?: string;
-  url?: string;
   type?: "website" | "article";
   product?: ProductName;
   robots?: string;
@@ -30,42 +28,26 @@ export function PageMeta(props: PageMetaProps) {
   const router = useRouterState();
   const currentPath = router.location.pathname;
 
-  const { title, description, image, url, type = "website", product, article, robots } = props;
+  const { title, description, image, type = "website", product, article, robots } = props;
 
   // Calculate metadata values
   const siteTitle = product ? `${PRODUCT_CONFIGS[product].title}` : "Mirascope";
   const pageTitle = title ? `${title} | ${siteTitle}` : siteTitle;
 
   // Generate image path if not provided
-  const computedImage = useMemo(() => {
-    if (image) return image;
+  const computedImage = image || routeToImagePath(currentPath);
 
-    // Use the generated social image path for this route
-    const generatedImage = routeToImagePath(currentPath);
-    return generatedImage;
-  }, [image, currentPath]);
-
-  // Handle URL construction
-  const ogUrl = url
-    ? url.startsWith("http")
-      ? url
-      : `${BASE_URL}${url.startsWith("/") ? url : `/${url}`}`
-    : `${BASE_URL}${currentPath}`;
-
-  // Create canonical URL with trailing slash removed for all URLs
-  const canonicalUrl = ogUrl.endsWith("/") ? ogUrl.slice(0, -1) : ogUrl;
+  // Create canonical URL following NTS rule (no trailing slash except homepage)
+  const canonicalPath = canonicalizePath(currentPath);
+  const canonicalUrl = `${BASE_URL}${canonicalPath}`;
 
   // Create absolute image URL
-  const ogImage = computedImage.startsWith("http")
-    ? computedImage
-    : `${BASE_URL}${computedImage.startsWith("/") ? computedImage : `/${computedImage}`}`;
-
-  //We don't need this anymore as we're adding the script element directly to the RouteMeta
+  const ogImage = computedImage.startsWith("http") ? computedImage : `${BASE_URL}${computedImage}`;
 
   return (
     <RouteMeta>
       <title>{pageTitle}</title>
-      <meta name="description" content={description} />
+      {description && <meta name="description" content={description} />}
       {robots && <meta name="robots" content={robots} />}
 
       {/* Canonical URL - self-referencing to prevent duplicate content issues */}
@@ -109,16 +91,16 @@ export function PageMeta(props: PageMetaProps) {
 
       {/* Open Graph / Facebook */}
       <meta property="og:type" content={type} />
-      <meta property="og:url" content={ogUrl} />
+      <meta property="og:url" content={canonicalUrl} />
       <meta property="og:title" content={pageTitle} />
-      <meta property="og:description" content={description} />
+      {description && <meta property="og:description" content={description} />}
       <meta property="og:image" content={ogImage} />
 
       {/* Twitter */}
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:url" content={ogUrl} />
+      <meta name="twitter:url" content={canonicalUrl} />
       <meta name="twitter:title" content={pageTitle} />
-      <meta name="twitter:description" content={description} />
+      {description && <meta name="twitter:description" content={description} />}
       <meta name="twitter:image" content={ogImage} />
 
       {/* Article specific metadata */}

--- a/src/components/mdx/providers/mdxComponentRegistry.tsx
+++ b/src/components/mdx/providers/mdxComponentRegistry.tsx
@@ -245,24 +245,64 @@ const mediaElements = {
   // Responsive image component
   img: (props: React.ComponentPropsWithoutRef<"img">) => <ResponsiveImage {...props} />,
   a: (props: React.ComponentPropsWithoutRef<"a">) => {
-    // Check if the link is internal
     const { href, ...rest } = props;
+    const navigate = useNavigate();
+
+    // Handle hash-only links (same page)
+    if (href?.startsWith("#")) {
+      const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+        e.preventDefault();
+        navigate({
+          hash: href.substring(1), // Remove the # prefix
+          replace: true,
+        });
+      };
+
+      return (
+        <a
+          href={href}
+          onClick={handleClick}
+          className="text-primary text-base no-underline hover:underline"
+          {...rest}
+        />
+      );
+    }
+
+    // Handle cross-page hash links (path + hash)
     if (
-      href &&
+      href?.includes("#") &&
       (href.startsWith("/") ||
-        (href !== "#" &&
-          !href.startsWith("http") &&
+        (!href.startsWith("http") &&
           !href.startsWith("https") &&
           !href.startsWith("mailto:") &&
           !href.startsWith("tel:")))
     ) {
-      // It's an internal link, use Link from TanStack Router
+      const [path, hash] = href.split("#");
+      return (
+        <Link
+          to={path}
+          hash={hash}
+          className="text-primary text-base no-underline hover:underline"
+          {...rest}
+        />
+      );
+    }
+
+    // Handle regular internal links
+    if (
+      href &&
+      (href.startsWith("/") ||
+        (!href.startsWith("http") &&
+          !href.startsWith("https") &&
+          !href.startsWith("mailto:") &&
+          !href.startsWith("tel:")))
+    ) {
       return (
         <Link to={href} className="text-primary text-base no-underline hover:underline" {...rest} />
       );
     }
 
-    // Use regular <a> for external links or anchor links
+    // Use regular <a> for external links
     return <a className="text-primary text-base no-underline hover:underline" {...props} />;
   },
 };

--- a/src/components/routes/blog/BlogIndexPage.tsx
+++ b/src/components/routes/blog/BlogIndexPage.tsx
@@ -77,7 +77,6 @@ export function BlogIndexPage({ posts }: BlogIndexPageProps) {
       <PageMeta
         title="Blog"
         description="The latest news, updates, and insights about Mirascope and LLM application development."
-        url="/blog"
         type="website"
       />
       <BlogLayout>

--- a/src/components/routes/blog/BlogPostPage.tsx
+++ b/src/components/routes/blog/BlogPostPage.tsx
@@ -127,7 +127,6 @@ export function BlogPostPage({ post, slug, isLoading = false }: BlogPostPageProp
         title={title}
         description={post.meta.description || post.mdx?.frontmatter?.excerpt}
         image={ogImage}
-        url={`/blog/${slug}`}
         type="article"
         article={{
           publishedTime: date,

--- a/src/components/routes/docs/DocsPage.tsx
+++ b/src/components/routes/docs/DocsPage.tsx
@@ -26,16 +26,14 @@ const DocsPage: React.FC<DocsPageProps> = ({ document, isLoading = false }) => {
   // Extract metadata for SEO (use defaults when loading)
   const meta = document?.meta || {
     title: "Loading...",
-    path: "",
     description: "Loading documentation content",
   };
-  const { title, path, description } = meta;
-  const urlPath = path ? `/docs/${path}` : "";
+  const { title, description } = meta;
   const product = useProduct();
 
   return (
     <>
-      <PageMeta title={title} description={description} url={urlPath} product={product} />
+      <PageMeta title={title} description={description} product={product} />
 
       <ProviderContextProvider>
         <AppLayout>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -118,3 +118,20 @@ export function slugify(text: string): string {
     "heading"
   ); // Default to 'heading' if nothing remains
 }
+
+/**
+ * Converts a route path to a canonical URL
+ * Rule: All URLs have no trailing slash except the homepage which keeps trailing slash
+ *
+ * @param path Route path (e.g., "/blog/my-post" or "/blog/my-post/")
+ * @returns Canonical path (e.g., "/blog/my-post" or "/" for homepage)
+ */
+export function canonicalizePath(path: string): string {
+  // Handle empty or root path
+  if (!path || path === "/" || path === "") {
+    return "/";
+  }
+
+  // Remove trailing slash for all non-root paths
+  return path.endsWith("/") ? path.slice(0, -1) : path;
+}

--- a/src/routes/dev/social-card.tsx
+++ b/src/routes/dev/social-card.tsx
@@ -2,7 +2,7 @@ import { createFileRoute, useLoaderData } from "@tanstack/react-router";
 import { useState, useEffect, useRef, useCallback } from "react";
 import DevLayout from "@/src/components/routes/dev/DevLayout";
 import { environment } from "@/src/lib/content/environment";
-import { getAllDevMeta } from "@/src/lib/content";
+import { getAllDevMeta, type ProductName } from "@/src/lib/content";
 import { LoadingContent, ContentErrorHandler } from "@/src/components";
 
 export const Route = createFileRoute("/dev/social-card")({
@@ -40,7 +40,7 @@ export const Route = createFileRoute("/dev/social-card")({
 // Helper interface for iframe communication
 declare global {
   interface Window {
-    updateSocialCard?: (title: string) => void;
+    updateSocialCard?: (title: string, product: ProductName) => void;
     SOCIAL_CARD_CONFIG?: {
       fontSizes: Array<{
         maxChars: number;
@@ -57,6 +57,7 @@ type FontSizeRule = { maxChars: number; fontSize: string; label: string };
 function SocialCardPreview() {
   const { devPages } = useLoaderData({ from: "/dev/social-card" });
   const [title, setTitle] = useState("Your Title Goes Here");
+  const [product, setProduct] = useState<ProductName>("mirascope");
   const [fontSizeRules, setFontSizeRules] = useState<FontSizeRule[]>([]);
 
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -65,9 +66,9 @@ function SocialCardPreview() {
   // Update the card when form values change
   useEffect(() => {
     if (iframeLoaded && iframeRef.current?.contentWindow?.updateSocialCard) {
-      iframeRef.current.contentWindow.updateSocialCard(title);
+      iframeRef.current.contentWindow.updateSocialCard(title, product);
     }
-  }, [title, iframeLoaded]);
+  }, [title, product, iframeLoaded]);
 
   // Get the current font size rule that applies to this title length
   const getCurrentFontSizeRule = useCallback((): FontSizeRule | undefined => {
@@ -85,7 +86,7 @@ function SocialCardPreview() {
 
     // Apply initial values
     if (iframeRef.current?.contentWindow?.updateSocialCard) {
-      iframeRef.current.contentWindow.updateSocialCard(title);
+      iframeRef.current.contentWindow.updateSocialCard(title, product);
     }
   };
 
@@ -118,6 +119,21 @@ function SocialCardPreview() {
             onChange={(e) => setTitle(e.target.value)}
             className="w-full rounded-md border px-3 py-2"
           />
+        </div>
+
+        <div className="mb-6">
+          <label htmlFor="product" className="mb-2 block font-medium">
+            Product
+          </label>
+          <select
+            id="product"
+            value={product}
+            onChange={(e) => setProduct(e.target.value as ProductName)}
+            className="w-full rounded-md border px-3 py-2"
+          >
+            <option value="mirascope">Mirascope</option>
+            <option value="lilypad">Lilypad</option>
+          </select>
         </div>
 
         <div className="flex justify-center">

--- a/src/routes/docs.$.tsx
+++ b/src/routes/docs.$.tsx
@@ -11,7 +11,13 @@ import { ContentErrorHandler } from "@/src/components";
 async function contentPathLoader({ params }: { params: { _splat: string } }) {
   // Construct the full route path from the splat parameter
   const splat = params._splat;
-  const routePath = `/docs/${splat}`;
+  let routePath = `/docs/${splat}`;
+
+  // Strip hash fragment if present - hash links should load the same content as the base page
+  const hashIndex = routePath.indexOf("#");
+  if (hashIndex !== -1) {
+    routePath = routePath.substring(0, hashIndex);
+  }
 
   try {
     // Look up DocInfo for this route path using the docRegistry

--- a/src/routes/pricing.tsx
+++ b/src/routes/pricing.tsx
@@ -224,7 +224,6 @@ function PricingPage() {
         title="Lilypad Pricing"
         description="Lilypad's pricing plans and features"
         product="lilypad"
-        url="/pricing"
       />
       <div className="px-4 py-4">
         <div className="mx-auto max-w-4xl">

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -39,7 +39,6 @@ function PrivacyPage() {
           content?.mdx?.frontmatter?.description ||
           "How Mirascope collects, uses, and protects your personal information."
         }
-        url="/privacy"
         type="article"
       />
       <PolicyPage content={content} type="privacy" />

--- a/src/routes/terms/service.tsx
+++ b/src/routes/terms/service.tsx
@@ -42,7 +42,6 @@ function TermsOfServicePage() {
           content?.mdx?.frontmatter?.description ||
           "Legal terms governing your use of Mirascope's platform and services."
         }
-        url="/terms/service"
         type="article"
       />
       <PolicyPage content={content} type="terms-service" />

--- a/src/routes/terms/use.tsx
+++ b/src/routes/terms/use.tsx
@@ -40,7 +40,6 @@ function TermsOfUsePage() {
           content?.mdx?.frontmatter?.description ||
           "Guidelines and rules for using the Mirascope website."
         }
-        url="/terms/use"
         type="article"
       />
       <PolicyPage content={content} type="terms-use" />


### PR DESCRIPTION
- Consistent link canonicalization rule: always drop the trailing slash, except for homepage where trailing slash is kept.
- Validation to ensure all internal links follow this rule
- rel=canonical meta set to reflect this
- (drive by fix: fix the docs/docs pathing in docs pages' og and canonical urls)
- Clientside redirects to canoncial links (potential future improvement: add static 301 redirects too)
- fix: internal links with hash components get turned into proper TanStack <Links>
- SEO social cards respect product branding (Lilypad logo and text) and have more logo padding
- remove unnecessary left sidebar vertical separator on app layout