### PR TITLE
fix: back to generating og-images before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "optimize-images": "bun run scripts/optimize-images.ts",
     "prebuild": "bun run preprocess-content",
     "build": "bun run --bun vite build && bun run prerender",
-    "build:full": "bun run prebuild && bun run --bun vite build && bun run generate-og-images && bun run optimize-images && bun run prerender && bun run postbuild",
+    "build:full": "bun run prebuild && bun run generate-og-images && bun run --bun vite build && bun run optimize-images && bun run prerender && bun run postbuild",
     "postbuild": "pagefind --site dist --output-path dist/_pagefind --root-selector '[data-pagefind-body=\"true\"]' --",
     "serve": "bun scripts/serve-static.js",
     "test": "bun test",


### PR DESCRIPTION
necessary so we have the seo-metadata.json in place when build copies it