### PR TITLE
fix: add more bottom padding to docs sidebar

### DIFF
--- a/src/components/core/layout/Sidebar.tsx
+++ b/src/components/core/layout/Sidebar.tsx
@@ -514,7 +514,7 @@ const Sidebar = ({ config, headerContent, footerContent }: SidebarProps) => {
         </div>
 
         {/* Fixed non-scrollable footer buffer */}
-        <div className="h-24 flex-shrink-0">
+        <div className="h-50 flex-shrink-0">
           {/* Footer content if provided */}
           {footerContent}
         </div>


### PR DESCRIPTION
hacky fix to accomodate having added a new sidebar section — ideally would rework the css to not depend on this