### PR TITLE
feat: add docs on thinking support

### DIFF
--- a/content/docs/mirascope/_meta.ts
+++ b/content/docs/mirascope/_meta.ts
@@ -100,6 +100,7 @@ const docsSection: SectionSpec = {
       slug: "learn/provider-specific",
       label: "Provider-Specific Features",
       children: [
+        { slug: "thinking-and-reasoning", label: "Thinking & Reasoning" },
         {
           slug: "openai",
           label: "OpenAI",

--- a/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
+++ b/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
@@ -30,34 +30,26 @@ the `@anthropic.call` provider-specific decorator, as in the example below. For 
 <TabbedSection>
 <Tab value="Response">
 ```py
-import inspect
-
-from dotenv import load_dotenv
-
-from mirascope.core import anthropic
-
-load_dotenv()
+from mirascope.core import anthropic, prompt_template
 
 
 @anthropic.call(
     model="claude-3-7-sonnet-latest",
-    call_params=anthropic.AnthropicCallParams(  # [!code highlight]
-        max_tokens=2048, # [!code highlight]
+    call_params=anthropic.AnthropicCallParams(
+        max_tokens=2048,
         thinking={"type": "enabled", "budget_tokens": 1024},  # [!code highlight]
-    ),  # [!code highlight]
+    ),
 )
-def answer() -> str:
-    return inspect.cleandoc(
-        """
-    Suppose a rocket is launched from a surface, pointing straight up.
-    For the first ten seconds, the rocket engine is providing upwards thrust of 
-    50m/s^2, after which it shuts off.
-    There is constant downwards acceleration of 10m/s^2 due to gravity.
-    What is the highest height it will achieve?
-    
-    Your final response should be ONLY a number in meters, with no additional text.
-    """
-    )
+@prompt_template("""
+Suppose a rocket is launched from a surface, pointing straight up.
+For the first ten seconds, the rocket engine is providing upwards thrust of
+50m/s^2, after which it shuts off.
+There is constant downwards acceleration of 10m/s^2 due to gravity.
+What is the highest height it will achieve?
+
+Your final response should be ONLY a number in meters, with no additional text.
+""")
+def answer(): ...
 
 
 response = answer()
@@ -69,35 +61,27 @@ print(response.content)  # [!code highlight]
 </Tab>
 <Tab value="Stream">
 ```py
-import inspect
-
-from dotenv import load_dotenv
-
-from mirascope.core import anthropic
-
-load_dotenv()
+from mirascope.core import anthropic, prompt_template
 
 
 @anthropic.call(
     model="claude-3-7-sonnet-latest",
-    call_params=anthropic.AnthropicCallParams(  # [!code highlight]
-        max_tokens=2048, # [!code highlight]
+    call_params=anthropic.AnthropicCallParams(
+        max_tokens=2048,
         thinking={"type": "enabled", "budget_tokens": 1024},  # [!code highlight]
-    ),  # [!code highlight]
+    ),
     stream=True,
 )
-def answer() -> str:
-    return inspect.cleandoc(
-        """
-    Suppose a rocket is launched from a surface, pointing straight up.
-    For the first ten seconds, the rocket engine is providing upwards thrust of 
-    50m/s^2, after which it shuts off.
-    There is constant downwards acceleration of 10m/s^2 due to gravity.
-    What is the highest height it will achieve?
-    
-    Your final response should be ONLY a number in meters, with no additional text.
-    """
-    )
+@prompt_template("""
+Suppose a rocket is launched from a surface, pointing straight up.
+For the first ten seconds, the rocket engine is providing upwards thrust of
+50m/s^2, after which it shuts off.
+There is constant downwards acceleration of 10m/s^2 due to gravity.
+What is the highest height it will achieve?
+
+Your final response should be ONLY a number in meters, with no additional text.
+""")
+def answer(): ...
 
 
 stream = answer()
@@ -134,37 +118,29 @@ For more, read the [Google documentation](https://ai.google.dev/gemini-api/docs/
 <TabbedSection>
 <Tab value="Response">
 ```python
-import inspect
-
-from dotenv import load_dotenv
 from google.genai import types
 
-from mirascope.core import google
-
-load_dotenv()
+from mirascope.core import google, prompt_template
 
 
 @google.call(
     model="gemini-2.5-flash-preview-05-20",
-    # [!code highlight:5]
     call_params={
         "config": types.GenerateContentConfig(
-            thinking_config=types.ThinkingConfig(include_thoughts=True)
+            thinking_config=types.ThinkingConfig(include_thoughts=True) # [!code highlight]
         ),
     },
 )
-def answer() -> str:
-    return inspect.cleandoc(
-        """
-    Suppose a rocket is launched from a surface, pointing straight up.
-    For the first ten seconds, the rocket engine is providing upwards thrust of 
-    50m/s^2, after which it shuts off.
-    There is constant downwards acceleration of 10m/s^2 due to gravity.
-    What is the highest height it will achieve?
-    
-    Your final response should be ONLY a number in meters, with no additional text.
-    """
-    )
+@prompt_template("""
+Suppose a rocket is launched from a surface, pointing straight up.
+For the first ten seconds, the rocket engine is providing upwards thrust of
+50m/s^2, after which it shuts off.
+There is constant downwards acceleration of 10m/s^2 due to gravity.
+What is the highest height it will achieve?
+
+Your final response should be ONLY a number in meters, with no additional text.
+""")
+def answer(): ...
 
 
 response = answer()
@@ -177,38 +153,30 @@ print(response.content)  # [!code highlight]
 
 <Tab value="Stream">
 ```python
-import inspect
-
-from dotenv import load_dotenv
 from google.genai import types
 
-from mirascope.core import google
-
-load_dotenv()
+from mirascope.core import google, prompt_template
 
 
 @google.call(
     model="gemini-2.5-flash-preview-05-20",
-    # [!code highlight:5]
     call_params={
         "config": types.GenerateContentConfig(
-            thinking_config=types.ThinkingConfig(include_thoughts=True)
+            thinking_config=types.ThinkingConfig(include_thoughts=True)  # [!code highlight]
         ),
     },
     stream=True,
 )
-def answer() -> str:
-    return inspect.cleandoc(
-        """
-    Suppose a rocket is launched from a surface, pointing straight up.
-    For the first ten seconds, the rocket engine is providing upwards thrust of 
-    50m/s^2, after which it shuts off.
-    There is constant downwards acceleration of 10m/s^2 due to gravity.
-    What is the highest height it will achieve?
-    
-    Your final response should be ONLY a number in meters, with no additional text.
-    """
-    )
+@prompt_template("""
+Suppose a rocket is launched from a surface, pointing straight up.
+For the first ten seconds, the rocket engine is providing upwards thrust of
+50m/s^2, after which it shuts off.
+There is constant downwards acceleration of 10m/s^2 due to gravity.
+What is the highest height it will achieve?
+
+Your final response should be ONLY a number in meters, with no additional text.
+""")
+def answer(): ...
 
 
 stream = answer()

--- a/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
+++ b/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
@@ -40,14 +40,15 @@ from mirascope.core import anthropic, prompt_template
         thinking={"type": "enabled", "budget_tokens": 1024},  # [!code highlight]
     ),
 )
-@prompt_template("""
-Suppose a rocket is launched from a surface, pointing straight up.
-For the first ten seconds, the rocket engine is providing upwards thrust of
-50m/s^2, after which it shuts off.
-There is constant downwards acceleration of 10m/s^2 due to gravity.
-What is the highest height it will achieve?
+@prompt_template(
+    """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
 
-Your final response should be ONLY a number in meters, with no additional text.
+    Your final response should be ONLY a number in meters, with no additional text.
 """)
 def answer(): ...
 
@@ -72,14 +73,15 @@ from mirascope.core import anthropic, prompt_template
     ),
     stream=True,
 )
-@prompt_template("""
-Suppose a rocket is launched from a surface, pointing straight up.
-For the first ten seconds, the rocket engine is providing upwards thrust of
-50m/s^2, after which it shuts off.
-There is constant downwards acceleration of 10m/s^2 due to gravity.
-What is the highest height it will achieve?
+@prompt_template(
+    """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
 
-Your final response should be ONLY a number in meters, with no additional text.
+    Your final response should be ONLY a number in meters, with no additional text.
 """)
 def answer(): ...
 
@@ -131,14 +133,15 @@ from mirascope.core import google, prompt_template
         ),
     },
 )
-@prompt_template("""
-Suppose a rocket is launched from a surface, pointing straight up.
-For the first ten seconds, the rocket engine is providing upwards thrust of
-50m/s^2, after which it shuts off.
-There is constant downwards acceleration of 10m/s^2 due to gravity.
-What is the highest height it will achieve?
+@prompt_template(
+    """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
 
-Your final response should be ONLY a number in meters, with no additional text.
+    Your final response should be ONLY a number in meters, with no additional text.
 """)
 def answer(): ...
 
@@ -167,14 +170,15 @@ from mirascope.core import google, prompt_template
     },
     stream=True,
 )
-@prompt_template("""
-Suppose a rocket is launched from a surface, pointing straight up.
-For the first ten seconds, the rocket engine is providing upwards thrust of
-50m/s^2, after which it shuts off.
-There is constant downwards acceleration of 10m/s^2 due to gravity.
-What is the highest height it will achieve?
+@prompt_template(
+    """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
 
-Your final response should be ONLY a number in meters, with no additional text.
+    Your final response should be ONLY a number in meters, with no additional text.
 """)
 def answer(): ...
 

--- a/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
+++ b/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
@@ -122,8 +122,13 @@ for chunk, _ in stream:
 <Tab value="Google">
 
 <Note>
-Google thinking is supported for the Gemini 2.5 series models. It may be invoked using
-the `@google.call` provider-specific decorator, as in the example below. For more, read the [Google documentation](https://ai.google.dev/gemini-api/docs/thinking).
+Google thinking is supported for the Gemini 2.5 series models. It is enabled by default, but may be configured specifically when using
+the `@google.call` provider-specific decorator. 
+
+The `include_thoughts` setting makes summaries of the thinking process available, as shown below. There is also a `thinking_budget` option, in Gemini 2.5 Flash,
+which allows fine tuning how many tokens are availble for thinking.
+
+For more, read the [Google documentation](https://ai.google.dev/gemini-api/docs/thinking).
 </Note>
 
 <TabbedSection>

--- a/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
+++ b/content/docs/mirascope/learn/provider-specific/thinking-and-reasoning.mdx
@@ -1,0 +1,226 @@
+---
+title: Thinking & Reasoning
+description: Enabling models to think or reason in Mirascope V1.
+---
+
+# Thinking & Reasoning
+
+Recent LLM models have support for "extended thinking", or "reasoning" in which, prior to generating a final output, the model produces internal reasoning about the task it has been given.
+
+We're currently working on Mirascope v2, which will support thinking in a generic and cross-provider way.
+However, as of Mirascope v1, we have ad-hoc thinking support added for the following providers:
+
+| Provider      | Can Use Thinking | Can View Thinking Summaries | 
+|---------------|:------:|:-------:|
+| Anthropic     | ✓      | ✓     |
+| Google Gemini | ✓      | ✓     |
+
+
+## Provider Examples
+
+<TabbedSection>
+
+<Tab value="Anthropic">
+
+<Note>
+Anthropic thinking is supported for Claude Opus 4, Claude Sonnet 4, and Claude Sonnet 3.7. It may be invoked using
+the `@anthropic.call` provider-specific decorator, as in the example below. For more, read the [Anthropic reasoning docs](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking).
+</Note>
+
+<TabbedSection>
+<Tab value="Response">
+```py
+import inspect
+
+from dotenv import load_dotenv
+
+from mirascope.core import anthropic
+
+load_dotenv()
+
+
+@anthropic.call(
+    model="claude-3-7-sonnet-latest",
+    call_params=anthropic.AnthropicCallParams(  # [!code highlight]
+        max_tokens=2048, # [!code highlight]
+        thinking={"type": "enabled", "budget_tokens": 1024},  # [!code highlight]
+    ),  # [!code highlight]
+)
+def answer() -> str:
+    return inspect.cleandoc(
+        """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of 
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
+    
+    Your final response should be ONLY a number in meters, with no additional text.
+    """
+    )
+
+
+response = answer()
+print("---- Thinking ----")
+print(response.thinking)  # [!code highlight]
+print("---- Response ----")
+print(response.content)  # [!code highlight]
+```
+</Tab>
+<Tab value="Stream">
+```py
+import inspect
+
+from dotenv import load_dotenv
+
+from mirascope.core import anthropic
+
+load_dotenv()
+
+
+@anthropic.call(
+    model="claude-3-7-sonnet-latest",
+    call_params=anthropic.AnthropicCallParams(  # [!code highlight]
+        max_tokens=2048, # [!code highlight]
+        thinking={"type": "enabled", "budget_tokens": 1024},  # [!code highlight]
+    ),  # [!code highlight]
+    stream=True,
+)
+def answer() -> str:
+    return inspect.cleandoc(
+        """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of 
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
+    
+    Your final response should be ONLY a number in meters, with no additional text.
+    """
+    )
+
+
+stream = answer()
+print("---- Thinking ----")
+still_thinking = True
+for chunk, _ in stream:
+    if chunk.thinking:  # [!code highlight]
+        print(chunk.thinking, end="", flush=True)
+    if chunk.signature:  # [!code highlight]
+        print(f"\n\nSignature: {chunk.signature}", end="\n", flush=True)
+    if chunk.content:  # [!code highlight]
+        if still_thinking:
+            print("---- Response ----", end="\n", flush=True)
+            still_thinking = False
+        print(chunk.content, end="", flush=True)
+```
+</Tab>
+</TabbedSection>
+
+</Tab>
+
+<Tab value="Google">
+
+<Note>
+Google thinking is supported for the Gemini 2.5 series models. It may be invoked using
+the `@google.call` provider-specific decorator, as in the example below. For more, read the [Google documentation](https://ai.google.dev/gemini-api/docs/thinking).
+</Note>
+
+<TabbedSection>
+<Tab value="Response">
+```python
+import inspect
+
+from dotenv import load_dotenv
+from google.genai import types
+
+from mirascope.core import google
+
+load_dotenv()
+
+
+@google.call(
+    model="gemini-2.5-flash-preview-05-20",
+    # [!code highlight:5]
+    call_params={
+        "config": types.GenerateContentConfig(
+            thinking_config=types.ThinkingConfig(include_thoughts=True)
+        ),
+    },
+)
+def answer() -> str:
+    return inspect.cleandoc(
+        """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of 
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
+    
+    Your final response should be ONLY a number in meters, with no additional text.
+    """
+    )
+
+
+response = answer()
+print("---- Thinking ----")
+print(response.thinking)  # [!code highlight]
+print("---- Response ----")
+print(response.content)  # [!code highlight]
+```
+</Tab>
+
+<Tab value="Stream">
+```python
+import inspect
+
+from dotenv import load_dotenv
+from google.genai import types
+
+from mirascope.core import google
+
+load_dotenv()
+
+
+@google.call(
+    model="gemini-2.5-flash-preview-05-20",
+    # [!code highlight:5]
+    call_params={
+        "config": types.GenerateContentConfig(
+            thinking_config=types.ThinkingConfig(include_thoughts=True)
+        ),
+    },
+    stream=True,
+)
+def answer() -> str:
+    return inspect.cleandoc(
+        """
+    Suppose a rocket is launched from a surface, pointing straight up.
+    For the first ten seconds, the rocket engine is providing upwards thrust of 
+    50m/s^2, after which it shuts off.
+    There is constant downwards acceleration of 10m/s^2 due to gravity.
+    What is the highest height it will achieve?
+    
+    Your final response should be ONLY a number in meters, with no additional text.
+    """
+    )
+
+
+stream = answer()
+print("---- Thinking ----")
+still_thinking = True
+for chunk, _ in stream:
+    if chunk.thinking:  # [!code highlight]
+        print(chunk.thinking, end="", flush=True)
+    if chunk.content:  # [!code highlight]
+        if still_thinking:
+            print("---- Response ----", end="\n", flush=True)
+            still_thinking = False
+        print(chunk.content, end="", flush=True)
+```
+</Tab>
+
+</TabbedSection>
+</Tab>
+
+</TabbedSection>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 
 dependencies = [
     # Core dependencies
-    "mirascope>=1.23.4",
+    "mirascope>=1.25.0",
     "pydantic>=2.7.4,<3.0",
     "griffe>=1.7.2",
     "tomli>=2.2.1",

--- a/src/components/mdx/elements/TabbedSection.tsx
+++ b/src/components/mdx/elements/TabbedSection.tsx
@@ -99,7 +99,7 @@ export function TabbedSection({
       <Tabs
         value={activeTab}
         defaultValue={firstTabValue}
-        className="font-handwriting w-full"
+        className="w-full"
         onValueChange={(newValue) => {
           if (saveTab) {
             saveTab(newValue);

--- a/uv.lock
+++ b/uv.lock
@@ -1488,7 +1488,7 @@ wheels = [
 
 [[package]]
 name = "mirascope"
-version = "1.23.4"
+version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docstring-parser" },
@@ -1496,9 +1496,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/9c/b56e69722097fd9f6db6b8978b3631bdb09efeebdcef866a3da0845bda13/mirascope-1.23.4.tar.gz", hash = "sha256:e5558bf12d5c8ed48922b306cb6b2feaf8690b5aaced3eb4716bfbbdb3e6b41b", size = 601852 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/7a/eb0480566d2270827c2f79e38d61db8fa823401aaea9e840daad97e13826/mirascope-1.25.0.tar.gz", hash = "sha256:77a1e054d8650251bbf0f06c1b693b3645ff292be4f527e6258747e17e1e17e0", size = 627246 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/c9/62122e6465383080b2021273f7c3a026e5e80eddac1e0b0b23bdd79925fc/mirascope-1.23.4-py3-none-any.whl", hash = "sha256:52931ceb24b91fb313cec76396cd72042b1ba35fa0ed9c7b8966d484d3e02553", size = 369827 },
+    { url = "https://files.pythonhosted.org/packages/30/f4/5b6cc66121e82294ae535441fd093e634bce1461c3b98832901e35dd271f/mirascope-1.25.0-py3-none-any.whl", hash = "sha256:38b790d8c028bfafacf4a581b177dbaf59cb717e0648a8aaf0d611f2a669d121", size = 373171 },
 ]
 
 [[package]]
@@ -1572,7 +1572,7 @@ requires-dist = [
     { name = "lilypad-sdk", specifier = ">=0.2.3" },
     { name = "litellm", marker = "extra == 'mirascope-all'", specifier = ">=1.42.12,<2" },
     { name = "mcp", marker = "extra == 'mirascope-all'", specifier = ">=1.6.0" },
-    { name = "mirascope", specifier = ">=1.23.4" },
+    { name = "mirascope", specifier = ">=1.25.0" },
     { name = "mistralai", marker = "extra == 'mirascope-all'", specifier = ">=1.0.0,<2" },
     { name = "numpy", marker = "extra == 'mirascope-all'", specifier = ">=1.26.4,<2" },
     { name = "openai", marker = "extra == 'mirascope-all'", specifier = ">=1.6.0,<2" },


### PR DESCRIPTION
Adds docs for thinking & reasoning support as of Mirascope v1.25.0:
https://d6059e97-website.william-025.workers.dev/docs/mirascope/learn/provider-specific/thinking-and-reasoning