### PR TITLE
Fix formatting issue in LangGraph guide

### DIFF
--- a/content/docs/mirascope/guides/langgraph-vs-mirascope/quickstart.mdx
+++ b/content/docs/mirascope/guides/langgraph-vs-mirascope/quickstart.mdx
@@ -208,7 +208,7 @@ Now that we have our tool defined, we can easily add the tool to our Mirascope c
 
 
 
-```python
+````python
 class Chatbot(BaseModel):
     history: list[BaseMessageParam | openai.OpenAIMessageParam] = []
 
@@ -293,7 +293,7 @@ Mirascope is compatible with Python versions 3.10 to 3.11 (not supporting Python
 ### Summary
 Mirascope positions itself as a simpler, less cumbersome alternative to other LLM frameworks like LangChain. It focuses on providing essential functionalities without unnecessary complexity, making development enjoyable and productive for software engineers looking to integrate LLMs into their applications.
 """
-```
+````
 
 
 We have enhanced our chatbot's functionality with several key modifications:


### PR DESCRIPTION
The [LangGraph Quickstart using Mirascope](https://mirascope.com/docs/mirascope/guides/langgraph-vs-mirascope/quickstart) guide has a formatting issue:

<img width="399" height="401" alt="docs" src="https://github.com/user-attachments/assets/41c412d5-7b41-4bf9-8360-0450c8386984" />

The issue stems from the nested backticks, namely there is the three bash backticks within the three python backticks.

To solve this, I used four backticks for the outer section. This renders correctly on GitHub.

If it does not render correctly on your website, you could instead just remove the pair of inner bash backticks.